### PR TITLE
Fix typo in Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-udo: false
+sudo: false
 language: node_js
 node_js:
   - stable


### PR DESCRIPTION
I was wondering was `udo` was all about, checked it with the Travis CI linter and noticed that it's probably supposed to be `sudo` :)