### PR TITLE
Disabled no-descending-specificity rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## UNRELEASED
 
-_Nothing yet..._
+### Fixed
+- Disabled `no-descending-specificity` rule
 
 ## 2.0.0-beta.1
 ### Changed

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ module.exports = {
       },
     ],
     'at-rule-no-unknown': null,
+    'no-descending-specificity': null,
     'scss/at-rule-no-unknown': true,
     'scss/at-function-pattern': [`^${kebabCase}$`, {
       message: 'Expected function to be kebab-case (scss/at-function-pattern)',


### PR DESCRIPTION
This disables `no-descending-specificity` for now. We felt that it was introducing too much disruption for little gain.