### PR TITLE
Adding prettier dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+# 2.2.0 - Adding prettier dependency
+
+- Added `prettier` as dependency
+
 ## 2.1.0 - Upgrading dependencies
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -8063,8 +8063,7 @@
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-      "dev": true
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "package.json": "npm run format:packagejson"
   },
   "dependencies": {
+    "prettier": "^1.19.1",
     "stylelint": "^13.3.3",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-standard": "^20.0.0",


### PR DESCRIPTION
Added prettier dependency to style lint as this can cause an error that prettier is not available in projects that are running just `stylelint-config-sksyscanner` and not `eslint-config-skyscanner`