### PR TITLE
[BPK-4015]: Add Backpack plugin dep ahead of development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1004,6 +1004,11 @@
         "type-detect": "4.0.8"
       }
     },
+    "@skyscanner/stylelint-plugin-backpack": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@skyscanner/stylelint-plugin-backpack/-/stylelint-plugin-backpack-0.0.1.tgz",
+      "integrity": "sha512-NGU9t6w0yqcNGDwPtcM7OwhvyC0hWd9Ad4zkLpJJrzUIEns+7fOeO1fKXgyeuOGo0ySy43mN4vUyikM8S6kLPg=="
+    },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.1",
       "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "package.json": "npm run format:packagejson"
   },
   "dependencies": {
+    "@skyscanner/stylelint-plugin-backpack": "0.0.1",
     "prettier": "^1.19.1",
     "stylelint": "^13.3.3",
     "stylelint-config-prettier": "^8.0.1",


### PR DESCRIPTION
Adding the `stylelint-plugin-backpack` lib to this repo so that we don't forget to add in the future. The current version does not have any code so has no effect right now, but means that dependabot will be able to monitor future versions as we develop the plugin.