### PR TITLE
Replace "unit-blacklist" with "unit-disallowed-list"

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -22,3 +22,4 @@ stylelint
 stylelint-config-skyscanner
 stylesheets
 uris
+v13.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Changed
+
+- Replace `unit-blacklist` with `unit-disallowed-list`. `unit-blacklist` was deprecated in [stylelint v13.7.0](https://github.com/stylelint/stylelint/blob/13.7.0/CHANGELOG.md#1370).
+
 ### Added
 
 - Upgraded dependency:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.org/Skyscanner/stylelint-config-skyscanner.svg?branch=master)](https://travis-ci.org/Skyscanner/stylelint-config-skyscanner)
 [![npm version](https://img.shields.io/npm/v/stylelint-config-skyscanner.svg)](https://www.npmjs.com/package/stylelint-config-skyscanner)
 
-
 Skyscanner's stylelint config.
 
 This stylelint config is based on [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard) with Skyscanner specific additions and is meant to be used with Backpack and `backpack-react-scripts`. Rules encourage developers to leverage the Backpack design system and to outsource development dependencies to `backpack-react-scripts`.
@@ -119,7 +118,7 @@ Avoid declaring your own `font-size` and `line-height`, use [`bpk-text-<size>` m
 
 Avoid declaring your own colours, use [`bpk-color-<color>` SCSS variables from Backpack](http://backpack.prod.aws.skyscnr.com/components/bonds/colors) instead.
 
-Rules: `unit-blacklist`, `scale-unlimited/declaration-strict-value`
+Rules: `unit-disallowed-list`, `scale-unlimited/declaration-strict-value`
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = {
     ],
     'selector-max-compound-selectors': 2,
     'declaration-no-important': true,
-    'unit-blacklist': ['px'],
+    'unit-disallowed-list': ['px'],
     'selector-class-pattern': [
       `^(${pascalCase}|${kebabCase})` + // block
       `(__(${camelCase}|${kebabCase}))?` + // element


### PR DESCRIPTION
`unit-blacklist` was deprecated in [stylelint v13.7.0](https://github.com/stylelint/stylelint/blob/13.7.0/CHANGELOG.md#1370).