### PR TITLE
Upgrade stylelint-plugin-backpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## UNRELEASED
 
+## 3.0.1 - Linter update
+
+### Added
+
+- Upgraded dependency:
+  - `stylelint-plugin-backpack` to `1.1.1`
+    - Fix bug in `backpack/use-tokens` rule where multiplications of tokens threw errors instead of passing.
+
 ## 3.0.0 - Rule update and new linter updates.
 
 ### Breaking
@@ -146,8 +154,6 @@
 - `at-rule-no-vendor-prefix`, `media-feature-name-no-vendor-prefix`, `property-no-vendor-prefix`, `selector-no-vendor-prefix`, `value-no-vendor-prefix` to encourage Autoprefixer usage
 - `string-quotes`, `selector-attribute-quotes`, `font-family-name-quotes` to standardise string usage
 - `unspecified: 'bottomAlphabetical'` to `order/properties-order` rule
-
-+
 
 ## 0.1.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-skyscanner",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1010,9 +1010,9 @@
       }
     },
     "@skyscanner/stylelint-plugin-backpack": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/stylelint-plugin-backpack/-/stylelint-plugin-backpack-1.1.0.tgz",
-      "integrity": "sha512-q/mcnkAlXHqaYnsJyEvlYcABzUsJ0tAWoCdMy83yy6tiERhMbLjJfB/kN3e4xvXvMUpBlDwe5yNXU8npqXn4RQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@skyscanner/stylelint-plugin-backpack/-/stylelint-plugin-backpack-1.1.1.tgz",
+      "integrity": "sha512-Or80PvmaNYziNnznZV5aIav7WiB8gOP9nQJRZgAOy1MJVFL36Rg9WObczzaFM0bF+CeD+sGkOZ/9dpCatYki5A==",
       "requires": {
         "bpk-tokens": "^32.0.5",
         "lodash": "^4.17.19",
@@ -9760,9 +9760,9 @@
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "tlds": {
-      "version": "1.208.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.208.0.tgz",
-      "integrity": "sha512-6kbY7GJpRQXwBddSOAbVUZXjObbCGFXliWWN+kOSEoRWIOyRWLB6zdeKC/Tguwwenl/KsUx016XR50EdHYsxZw=="
+      "version": "1.212.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.212.0.tgz",
+      "integrity": "sha512-03rYYO1rGhOYpdYB+wlLY2d0xza6hdN/S67ol2ZpaH+CtFedMVAVhj8ft0rwxEkr90zatou8opBv7Xp6X4cK6g=="
     },
     "tmp": {
       "version": "0.0.29",
@@ -10117,9 +10117,9 @@
       },
       "dependencies": {
         "ip-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-          "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
+          "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-skyscanner",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Skyscanner's stylelint config.",
   "license": "Apache-2.0",
   "engines": {
@@ -44,7 +44,7 @@
     "package.json": "npm run format:packagejson"
   },
   "dependencies": {
-    "@skyscanner/stylelint-plugin-backpack": "^1.1.0",
+    "@skyscanner/stylelint-plugin-backpack": "^1.1.1",
     "eslint-config-skyscanner": "^8.0.0",
     "stylelint": "^13.7.2",
     "stylelint-config-prettier": "^8.0.2",


### PR DESCRIPTION
This brings in a fix for the 'use-tokens' rule where it, in error,
flagged multiplies of tokens as invalid.

Relates to: https://github.com/Skyscanner/stylelint-plugin-backpack/releases/tag/v1.1.1