### PR TITLE
Allow "currentcolor"

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,6 @@
 # UNRELEASED
 
 This project adheres to [Semantic Versioning](http://semver.org/).
+
+### Updated
+- Allow using `currentcolor` keyword.

--- a/index.js
+++ b/index.js
@@ -119,9 +119,9 @@ module.exports = {
       ['/color/', 'fill', 'stroke', 'font-size', 'line-height'],
       {
         ignoreKeywords: {
-          '/color/': ['currentColor', 'transparent', 'inherit'],
-          fill: ['currentColor', 'transparent', 'inherit'],
-          stroke: ['currentColor', 'transparent', 'inherit'],
+          '/color/': ['currentcolor', 'currentColor', 'transparent', 'inherit'],
+          fill: ['currentcolor', 'currentColor', 'transparent', 'inherit'],
+          stroke: ['currentcolor', 'currentColor', 'transparent', 'inherit'],
         },
         disableFix: true,
       },

--- a/index.test.js
+++ b/index.test.js
@@ -37,6 +37,7 @@ const validCss = `$kebab-case-variable: 3rem;
 
   &--camelCaseModifier {
     display: block;
+    color: currentcolor;
   }
 
   &__camelCaseElement {


### PR DESCRIPTION
This [`stylelint` bump](https://github.com/Skyscanner/stylelint-config-skyscanner/pull/170) included a change to use `currentcolor` instead of `currentColor` (adding a config to keep the old name).

Our `scale-unlimited/declaration-strict-value` only allows `currentColor`, so currently it's not possible to use `currentcolor` nor `currentColor`.

Allowing both in `scale-unlimited/declaration-strict-value` will allow clients to use the default one (`currentcolor` ) or the legacy one (`currentColor`).

See more context about `currentcolor` change in the `stylelint` [pr discussion](https://github.com/stylelint/stylelint/pull/5849) and the [original issue](https://github.com/stylelint/stylelint/issues/4884).