### PR TITLE
Update `unit-disallowed-list` to allow px in some cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = {
       'px',
       {
         ignoreProperties: {
-          px: ['margin-top', 'margin-bottom', '/^padding/', 'border-width'],
+          px: ['margin-top', 'margin-bottom', '/^padding/', '/^border/'],
         },
       },
     ],

--- a/index.js
+++ b/index.js
@@ -44,7 +44,14 @@ module.exports = {
     ],
     'selector-max-compound-selectors': 2,
     'declaration-no-important': true,
-    'unit-disallowed-list': ['px'],
+    'unit-disallowed-list': [
+      'px',
+      {
+        ignoreProperties: {
+          px: ['margin-top', 'margin-bottom', '/^padding/', 'border-width'],
+        },
+      },
+    ],
     'selector-class-pattern': [
       `^(${pascalCase}|${kebabCase})` + // block
         `(__(${camelCase}|${kebabCase}))?` + // element

--- a/index.test.js
+++ b/index.test.js
@@ -406,3 +406,45 @@ describe('flags use-typography-styles', () => {
       ),
     ));
 });
+
+const unitsUsageCSS = `.valid-usage {
+  margin-top: 20px;
+  margin-top: 10px;
+  margin-bottom: 100px;
+  padding: 20px 2rem;
+  padding-top: 20px;
+  border: 1px solid #fff;
+  border-width: 10px;
+}
+
+.invalid-usage {
+  margin: 10px 1rem;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+`;
+
+describe('flags unit-disallowed-list', () => {
+  let result;
+
+  beforeEach(() => {
+    result = stylelint.lint({
+      code: unitsUsageCSS,
+      config,
+    });
+  });
+
+  it('raise errors when invalid usage', () =>
+    result.then((data) => {
+      expect(data.errored).toBe(true);
+      expect(data.results[0].warnings).toHaveLength(3);
+
+      data.results[0].warnings.forEach((warn) => {
+        expect(warn).toMatchObject(
+          expect.objectContaining({
+            rule: 'unit-disallowed-list',
+          }),
+        );
+      });
+    }));
+});


### PR DESCRIPTION
According to the new agreement to allow `px` in some cases.

[`unit-disallowed-list` docs](https://stylelint.io/user-guide/rules/list/unit-disallowed-list/#optional-secondary-options)

Playground: https://stylelint.io/demo/#N4Igxg9gJgpiBcIB0YA2BDAzpgBMAOgHY44AO6UUAloQObw4BMADKQB4DcRJ5lNtAWgAuEUgxbsuxHAFt0AJ1o1ho8a07ccAIwjzY8hgEZ2OTBFRUoOAMQAze1JJzFNI+pyH5MGRxwB6PxwYeXldTWclQhUxD3VHWQVIgR0hERk3OKIAXxAAGhBMAE9CIXQ2BHBsPPAIQlsqWgqCaXwQeQBXVBhMVoZmkhJW9sIqIQFqTHRUVAgAdxgoAQtMIV6cAG1NAZxW9lbcrYH+7YHWhsJdGAAFUNJgoSputeOT05A9hA3WiOURUn2diAflEUmkAa0-AA9XjUOh+cEgKE6PTBeEgAC6h22WSxOBx0hImOk+JyWSAA

<img width="1219" alt="image" src="https://user-images.githubusercontent.com/13509022/178287134-07270ef7-8d28-4c38-8f10-e97184f50994.png">
