### PR TITLE
 Upgrade node version to support 18 / hydrogen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,8 @@
         "lint-staged": "^12.3.8"
       },
       "engines": {
-        "node": "^16.13.0",
-        "npm": "^8.1.0"
+        "node": ">=16.13.0",
+        "npm": ">=8.1.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Skyscanner's stylelint config.",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16.13.0",
-    "npm": "^8.1.0"
+    "node": ">=16.13.0",
+    "npm": ">=8.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To properly support in other node18 projects, Upgrading stylelint-config to work with 16 and above.