### PR TITLE
Add docs around ECS affect on versions, prepare 7.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [Unreleased changes](./UNRELEASED.md)
 
+## 6.1.0 (deprecated)
+### Updated
+
+- Bump @skyscanner/eslint-config-skyscanner from 12.6.1 to 13.1.0
+- Bump stylelint-config-prettier from 9.0.3 to 9.0.4
+- Bump json5 from 1.0.1 to 1.0.2 (security bump)
+
+This version was incorrectly released as a minor bump, when the side effect of the `@skyscanner/eslint-config-skyscanner` bump to consumers justified it being a major bump. It has been marked as deprecated in npm, and version `7.0.0` should be used instead as soon as it is published.
+
 ## 6.0.2
 
 - Update `@skyscanner/stylelint-plugin-backpack` and `@skyscanner/eslint-config-skyscanner`

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,7 +1,12 @@
 # UNRELEASED
 
+_If `@skyscanner/eslint-config-skyscanner` has a major version change then `@skyscanner/stylelint-config-skyscanner` should also have a major version change, as explained in [the docs](./docs/eslint-as-dependency.md)_
+
+## 7.0.0
 ### Updated
 
-- Bump @skyscanner/eslint-config-skyscanner to 13.1.0
+- Bump @skyscanner/eslint-config-skyscanner from 12.6.1 to 13.1.0
 - Bump stylelint-config-prettier from 9.0.3 to 9.0.4
 - Bump json5 from 1.0.1 to 1.0.2 (security bump)
+
+As `@skyscanner/eslint-config-skyscanner` is shipped as `dependency` then this may cause JavaScript linting changes in your project as a side effect if you have no already updated. If that is the case it is the recommendation to also update `@skyscanner/eslint-config-skyscanner` and follow its [release notes](https://github.com/Skyscanner/eslint-config-skyscanner/releases/tag/v13.0.0).

--- a/docs/eslint-as-dependency.md
+++ b/docs/eslint-as-dependency.md
@@ -1,0 +1,15 @@
+# ESLint as a dependency
+
+`@skyscanner/eslint-config-skyscanner` (ECS) is installed as a `dependency` rather than a `devDependency`.
+
+This was done in https://github.com/Skyscanner/stylelint-config-skyscanner/pull/63.
+
+ECS depends on Prettier. `@skyscanner/eslint-config-skyscanner` (SCS) also includes Prettier. If Prettier is installed at the top level of SCS then conflicts happen between it, Prettier, and Prettier within ECS.
+
+Conflicts then happen when SCS and ECS are installed in the same consumer. This can lead to unexpected behaviours, with consumers being locked to unexpected versions of Prettier.
+
+Instead SCS does not specify which version of Prettier it uses, and installs ECS as a main dependency, using ECS's version of Prettier as its own. SCS then ships with ECS bundled, allowing consumers to update to the latest of each and have a tree that is in sync.
+
+The downside here is that **major versions of ECS mean a new major version of SCS must be released**, as consumers resolve nested dependencies based on it.
+
+There is no perfect solution here, but the above is felt to be the most reasonable trade off.


### PR DESCRIPTION
`eslint-config-skyscanner` major version bumps should trigger a major version of `stylelint-config-skyscanner`. We decided this a long time ago, but in https://github.com/Skyscanner/stylelint-config-skyscanner/pull/255 I forgot.

This PR sets up for deprecating the latest release, https://github.com/Skyscanner/stylelint-config-skyscanner/commit/bfe68009639abfddf148b94a4bc2ceb165dcec11, releasing a `7.0.0` version, and adds some documentation so we don't have to pick through old PRs to remember this.