### PR TITLE
[KOA-6224] Adjust non-compatible rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,11 @@ module.exports = {
     // https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties/
     'declaration-block-no-redundant-longhand-properties': null,
 
+    // This suggests syntax that is not compatible with node-sass. It is blocked until we move our standard tooling to dart sass.
+    // https://github.com/Skyscanner/backpack-react-scripts/blob/ccba8c3ae8b3cb178dd8ac4efa749328ede8928b/packages/react-scripts/package.json#L57
+    // https://stylelint.io/user-guide/rules/media-feature-range-notation/
+    'media-feature-range-notation': null,
+
     'selector-max-id': 0,
     'selector-max-type': [
       0,
@@ -80,12 +85,6 @@ module.exports = {
         except: ['blockless-after-same-name-blockless', 'first-nested'],
         ignore: ['after-comment'],
         ignoreAtRules: ['else'],
-      },
-    ],
-    'block-closing-brace-newline-after': [
-      'always',
-      {
-        ignoreAtRules: ['if', 'else'],
       },
     ],
     'at-rule-no-unknown': null,


### PR DESCRIPTION
The side effects of `media-feature-range-notation` at _build_ time were missed in 
https://github.com/Skyscanner/stylelint-config-skyscanner/pull/293.


The deprecation of `block-closing-brace-newline-after` was missed from checking this list: https://stylelint.io/user-guide/rules#deprecated

https://stylelint.io/user-guide/rules/block-closing-brace-newline-after/