### PR TITLE
Replaced depreacted at-import-no-partial-leading-underscore

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = {
           'Expected function to be kebab-case (scss/at-function-pattern)',
       },
     ],
-    'scss/at-import-no-partial-leading-underscore': true,
+    'scss/load-no-partial-leading-underscore': true,
     'scss/at-mixin-argumentless-call-parentheses': 'never',
     'scss/at-mixin-pattern': [
       `^_?${kebabCase}(__${kebabCase})?(--${kebabCase}?)?-?$`,


### PR DESCRIPTION
Context

`at-import-no-partial-leading-underscore` has been deprecated in favour of load-no-partial-leading-underscore. We should update our index.js to use load-no-partial-leading-underscore.

For context on change see https://github.com/stylelint-scss/stylelint-scss/pull/867

Docs for - `at-import-no-partial-leading-underscore` https://github.com/stylelint-scss/stylelint-scss/blob/v5.2.1/src/rules/at-import-no-partial-leading-underscore/README.md
Doc for `load-no-partial-leading-underscore` https://github.com/stylelint-scss/stylelint-scss/blob/d245813e783cc3cb3f8f946cc293a041202b995e/src/rules/load-no-partial-leading-underscore/README.md

The change includes a new potential warning
`@use "sass:meta";
.a {
  @include meta.load-css("_fff", $with: ("border-contrast": true));
}`