### PR TITLE
[ARGG-1057]: Setup dependabot to ignore patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "10:00"
-  open-pull-requests-limit: 10
-  versioning-strategy: increase
-  ignore:
-  - dependency-name: husky
-    versions:
-    - ">= 5.a, < 6"
-  - dependency-name: stylelint
-    versions:
-    - 13.10.0
-    - 13.11.0
-    - 13.9.0
-  - dependency-name: husky
-    versions:
-    - 4.3.8
-  - dependency-name: stylelint-declaration-strict-value
-    versions:
-    - 1.7.7
-  - dependency-name: lint-staged
-    versions:
-    - 10.5.3
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      time: '10:00'
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']


### PR DESCRIPTION
Patch versions generate a lot of toil without providing a high amount of value.

We can opt out of receiving automated PRs for these, while still receiving PRs for minor and major versions.

https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore
