### PR TITLE
Update to actions/cache v4.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upload to Cache
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4.2.0
         id: npm-cache
         with:
           path: |
@@ -57,7 +57,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Restore Cache
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4.2.0
         id: npm-cache
         with:
           path: |


### PR DESCRIPTION
The latest release workflow failed as the repo is using a deprecated actions/cache version that GitHub bails out of running. This PR updates to a newer version.

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/649fd369-bbb5-46bb-8850-a570caa944ad" />


https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down