### PR TITLE
Set load-partial-extension rule to never

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ const config = {
     'scss/at-else-empty-line-before': 'never',
     'scss/at-if-closing-brace-newline-after': 'always-last-in-chain',
     'scss/at-if-closing-brace-space-after': 'always-intermediate',
-    'scss/load-partial-extension': 'always',
+    'scss/load-partial-extension': 'never',
     'scale-unlimited/declaration-strict-value': [
       ['/color/', 'fill', 'stroke', 'font-size', 'line-height'],
       {


### PR DESCRIPTION
### What is the change?
Set load-partial-extension rule to `never`. This ensures that _no_ Sass import uses file extensions.

### Context
In the previous version of stylelint-config-skyscanner we were using a different plugin that was set to `always` require file extensions in imports. However, it was broken and was not failing despite not using extensions.

### Why are we making this change?
- the linting rule can automatically fix the errors if the plugin is set to `never` require the extension. If set to `always` this isn't possible and requires manual changes, or a custom script to update imports throughout the codebase. This means easier adoption for consumers.
- if importing CSS, you _must not_ use the extension
  -  source: https://sass-lang.com/documentation/at-rules/import/#importing-css
- Sass documentation does not recommend a way of doing, nor does it reference any performance impact
  - source: https://sass-lang.com/documentation/at-rules/import/#finding-the-file

### Versioning
Since this is automatically fixable with `--fix` command, it is not considered a `breaking` change. Hence this will be marked as `minor`.